### PR TITLE
Minor revisions to cloudwatch-to-splunk lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ module "foo" {
   source = "git@github.com:techservicesillinois/terraform-aws-cloudwatch-to-splunk//"
   # NOTE: Normally, callers will NOT specify the function name, except when
   # deploying a test version of the lambda code.
-  # function_name = cloudwatch_to_splunk  
+  # function_name = cloudwatch-to-splunk
 }
 ```
 
@@ -24,7 +24,15 @@ Argument Reference
 The following arguments are supported:
 
 * `function_name` - Name of the lambda function and role to be deployed
-(default: *cloudwatch_to_splunk*)
+(default: *cloudwatch-to-splunk*). **NOTE:** In general, this should not
+be overridden by end users.
+
+* `memory_size` - Amount of memory in MB for lambda function
+(default: "512").  **NOTE:** In general, this should not be overridden by
+end users.
+
+* `runtime` - Lambda function's runtime environment (default: nodejs8.10).
+**NOTE:** In general, this should not be overridden by end users.
 
 * `splunk_cache_ttl` - Time-to-live value for cached Splunk connection
 in milliseconds (default: *6000*)

--- a/main.tf
+++ b/main.tf
@@ -8,16 +8,21 @@ resource "aws_cloudwatch_log_group" "default" {
 }
 
 resource "aws_lambda_function" "default" {
-  description   = "Stream events from AWS CloudWatch to Splunk event collector"
+  description = "Stream events from AWS CloudWatch to Splunk event collector"
+
+  # The function_name, runtime, memory_size, and timeout use variables
+  # to facilitate testing of both new runtimes and new function versions.
+  # End users will ordinarily use the default values.
   function_name = "${var.function_name}"
-  handler       = "index.handler"
-  publish       = "true"
-  role          = "${aws_iam_role.default.arn}"
-  runtime       = "nodejs6.10"
-  memory_size   = "512"
-  timeout       = "10"
-  s3_bucket     = "drone-${local.region}-${local.account_id}"
-  s3_key        = "splunk-aws-serverless-apps/splunk-cloudwatch-logs-processor.zip"
+
+  runtime     = "${var.runtime}"
+  memory_size = "${var.memory_size}"
+  timeout     = "${var.timeout}"
+  handler     = "index.handler"
+  publish     = "true"
+  role        = "${aws_iam_role.default.arn}"
+  s3_bucket   = "drone-${local.region}-${local.account_id}"
+  s3_key      = "splunk-aws-serverless-apps/splunk-cloudwatch-logs-processor.zip"
 
   environment {
     variables = {

--- a/variables.tf
+++ b/variables.tf
@@ -1,13 +1,34 @@
-# Normally, callers will use the default for ${var.function_name}, but
-# overriding may be useful for testing.
+##### Variables for aws_lambda_function resource.
+
+# The function_name, runtime, memory_size, and timeout use variables
+# to facilitate testing of both new runtimes and new function versions.
+# End users will ordinarily use the default values.
+
 variable "function_name" {
   description = "Name of the lambda function and role to be deployed"
-  default     = "cloudwatch_to_splunk"
+  default     = "cloudwatch-to-splunk"
+}
+
+variable "memory_size" {
+  description = "Amount of memory in MB for lambda function"
+  default     = "512"
+}
+
+variable "runtime" {
+  description = "Lambda function's runtime environment"
+  default     = "nodejs8.10"
+}
+
+variable "timeout" {
+  description = "Time limit in seconds for lambda function"
+  default     = "10"
 }
 
 variable "splunk_cache_ttl" {
   description = "Time-to-live value for cached Splunk connection in milliseconds"
-  default = "6000"    # 6 minutes.
+
+  # Default cache TTL is 6 minutes.
+  default = "6000"
 }
 
 variable "ssm_prefix" {


### PR DESCRIPTION
*   Added variables for function_name, runtime, memory_size, and timeout
    to facilitate testing of both new runtimes and new function versions.
    End users will almost NEVER override the default values.

*   Change function name from underscores to hyphens to be consistent
    with other lambda functions we've deployed.