### PR TITLE
Update lambda runtime to nodejs12.x

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,0 @@
-pipeline:
-  build:
-    image: hashicorp/terraform
-    commands:
-      - apk add make
-      - make

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,82 @@
+# Some of this logic was stolen from https://www.freecodecamp.org/news/a-lightweight-tool-agnostic-ci-cd-flow-with-github-actions/
+
+name: terraform
+
+on:
+  push:
+#   branches:
+#     - master
+  pull_request:
+
+jobs:
+  terraform:
+    name: terraform
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+
+      - name: terraform setup
+        uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 0.12.29
+      #   cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+
+#     TODO: This step duplicates work done by the Makefile.
+#     - name: check terraform formatting
+#       id: fmt
+#       run: |
+#         terraform fmt -check -recursive
+
+      - name: run make
+      # env:
+      #   TOKEN: ${{ secrets.TOKEN }}
+        run: |
+          make all
+
+#     - name: terraform init
+#       id: init
+#       run: terraform init
+#
+#      - name: terraform plan
+#        id: plan
+#        if: github.event_name == 'pull_request'
+#        run: terraform plan -no-color
+#        continue-on-error: true
+#
+#      - uses: actions/github-script@0.9.0
+#        if: github.event_name == 'pull_request'
+#        env:
+#          PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
+#        with:
+#          github-token: ${{ secrets.GITHUB_TOKEN }}
+#          script: |
+#            const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
+#            #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
+#            #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
+#
+#            <details><summary>Show Plan</summary>
+#
+#            \`\`\`${process.env.PLAN}\`\`\`
+#
+#            </details>
+#
+#            *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`*`;
+#
+#              
+#            github.issues.createComment({
+#              issue_number: context.issue.number,
+#              owner: context.repo.owner,
+#              repo: context.repo.repo,
+#              body: output
+#            })
+#
+#      - name: terraform plan status
+#        if: steps.plan.outcome == 'failure'
+#        run: exit 1
+#
+#      - name: terraform apply
+#        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+#        run: terraform apply -auto-approve

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/terraform
+FROM hashicorp/terraform:0.12.30
 
 RUN apk add make
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
-.PHONY: test clean docker sh shell
+.PHONY: all test clean docker sh shell
 
 REPO := $(shell basename $(shell git remote get-url origin) .git)
+
+all: test
 
 test: .terraform
 	AWS_DEFAULT_REGION=us-east-2 terraform validate
@@ -18,8 +20,8 @@ test: .terraform
 	! egrep 'output\s+"\w+"\s*\{' $(shell find . -name '*.tf' ! -name outputs.tf)
 	# Do NOT define a variable in files other than variables.tf
 	! egrep 'variable\s+"\w+"\s*\{' $(shell find . -name '*.tf' ! -name variables.tf)
-	# DO put a badge in README.md
-	grep -q "\[\!\[Build Status\]([^)]*$(REPO)/status.svg)\]([^)]*$(REPO))" README.md
+	# DO put a badge in top-level README.md
+	grep -q "\[\!\[Terraform actions status\]([^)]*$(REPO)/workflows/terraform/badge.svg)\]([^)]*$(REPO)/actions)" README.md
 	# Do NOT use ?ref= in source lines in a README.md!
 	! grep 'source\s*=.*?ref=' *.tf README.md
 	# Do NOT start a source line with git::

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cloudwatch-to-splunk
 
-[![Build Status](https://drone.techservices.illinois.edu/api/badges/techservicesillinois/terraform-aws-cloudwatch-to-splunk/status.svg)](https://drone.techservices.illinois.edu/techservicesillinois/terraform-aws-cloudwatch-to-splunk)
+[![Terraform actions status](https://github.com/techservicesillinois/terraform-aws-cloudwatch-to-splunk/workflows/terraform/badge.svg)](https://github.com/techservicesillinois/terraform-aws-cloudwatch-to-splunk/actions)
 
 Provides a lambda function that can be used with an arbitrary number of CloudWatch log groups to forward logs to [Splunk](https://www.splunk.com/). Each log group requires
 a log filter and configuration using [AWS Systems Manager
@@ -33,14 +33,15 @@ be overridden by end users.
 (default: 512).  **NOTE:** In general, this should not be overridden by
 end users.
 
-* `runtime` - Lambda function's runtime environment (default: nodejs8.10).
-**NOTE:** In general, this should not be overridden by end users.
+* `runtime` - Lambda function's runtime environment.
+**NOTE:** This *_must_* be a `nodejs` environment supported by Amazon.
+See the [AWS documentation on Lambda runtime environments](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html).
 
 * `splunk_cache_ttl` - Time-to-live value for cached Splunk connection
-in milliseconds (default: *6000*)
+in milliseconds (default: 360000 seconds, which is equal to 6 minutes).
 
 * `ssm_prefix` - Prefix string to be applied to look up runtime SSM
-variables (default: *cloudwatch_to_splunk*)
+variables (default: *cloudwatch\_to\_splunk*).
 
 Attributes Reference
 --------------------

--- a/main.tf
+++ b/main.tf
@@ -21,8 +21,9 @@ resource "aws_lambda_function" "default" {
   handler     = "index.handler"
   publish     = true
   role        = aws_iam_role.default.arn
-  s3_bucket   = "drone-${local.region}-${local.account_id}"
+  s3_bucket   = format("drone-%s-%s", local.region, local.account_id)
   s3_key      = "splunk-aws-serverless-apps/splunk-cloudwatch-logs-processor.zip"
+  tags        = var.tags
 
   environment {
     variables = {

--- a/variables.tf
+++ b/variables.tf
@@ -16,7 +16,6 @@ variable "memory_size" {
 
 variable "runtime" {
   description = "Lambda function's runtime environment"
-  default     = "nodejs8.10"
 }
 
 variable "timeout" {
@@ -27,11 +26,17 @@ variable "timeout" {
 variable "splunk_cache_ttl" {
   description = "Time-to-live value for cached Splunk connection in milliseconds"
 
-  # Default cache TTL is 6 minutes.
-  default = 6000
+  # Set default cache TTL.
+  default = 6 * 60 * 1000 # 6 minutes expressed in milliseconds.
 }
 
 variable "ssm_prefix" {
-  description = "Prefix string to be applied to look up runtime SSM variables)"
+  description = "Prefix string to be applied to look up runtime SSM variables"
   default     = "/cloudwatch_to_splunk"
+}
+
+variable "tags" {
+  description = "A mapping of tags to be supplied to resources where supported"
+  type        = map(string)
+  default     = {}
 }


### PR DESCRIPTION
Remove the hardcoded runtime environment in the module. This can be specified by the caller, allowing the runtime to be upgraded more easily.

Computed the millisecond equivalent of 6 minutes incorrectly at 6000. That's 6 *seconds*. We want 6 * 60 * 100, which comes to 360000. Oops.

Fixed a bunch of minor documentation errors.

While we're at it, got rid of Drone.