### PR TITLE
Update for Terraform CloudWatch log group ARN output change

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -17,7 +17,7 @@ data "aws_iam_policy_document" "default" {
       "logs:DescribeLogStreams",
     ]
 
-    resources = [aws_cloudwatch_log_group.default.arn]
+    resources = [format("%s:*", aws_cloudwatch_log_group.default.arn)]
   }
 
   statement {
@@ -26,8 +26,8 @@ data "aws_iam_policy_document" "default" {
     ]
 
     resources = [
-      aws_cloudwatch_log_group.default.arn,
-      "${aws_cloudwatch_log_group.default.arn}:*:*",
+      format("%s:*", aws_cloudwatch_log_group.default.arn),
+      format("%s:*:*:*", aws_cloudwatch_log_group.default.arn)
     ]
   }
 


### PR DESCRIPTION
Terraform's v3 provider changes the format of ARNs produced by CloudWatch log group resources and data sources. This fix addresses the breaking changes that apply to some configurations.