### PR TITLE
Allow specifying retention period for CloudWatch logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ module "foo" {
   source = "git@github.com:techservicesillinois/terraform-aws-cloudwatch-to-splunk//"
   # NOTE: Normally, callers will NOT specify the function name, except when
   # deploying a test version of the lambda code.
-  # function_name = cloudwatch-to-splunk
+  # name = cloudwatch-to-splunk
 }
 ```
 
@@ -25,13 +25,15 @@ Argument Reference
 
 The following arguments are supported:
 
-* `function_name` - Name of the lambda function and role to be deployed
+* `name` - Name of the lambda function and role to be deployed
 (default: *cloudwatch-to-splunk*). **NOTE:** In general, this should not
 be overridden by end users.
 
 * `memory_size` - Amount of memory in MB for lambda function
 (default: 512).  **NOTE:** In general, this should not be overridden by
 end users.
+
+* `retention` - Log retention period in days (default: 30 days).
 
 * `runtime` - Lambda function's runtime environment.
 **NOTE:** This *_must_* be a `nodejs` environment supported by Amazon.

--- a/iam.tf
+++ b/iam.tf
@@ -72,15 +72,31 @@ data "aws_iam_policy_document" "assume-role-policy" {
 resource "aws_iam_policy" "default" {
   name        = var.function_name
   path        = "/"
-  description = "Policy controlling access granted to lambda function ${var.function_name}"
+  description = "CloudWatch access for ${var.function_name} lambda"
   policy      = data.aws_iam_policy_document.default.json
+  tags        = local.tags
+
+  lifecycle {
+    ignore_changes = [
+      # Don't replace policy if description is changed.
+      description,
+    ]
+  }
 }
 
 resource "aws_iam_role" "default" {
   name               = var.function_name
   path               = "/"
-  description        = "Role assumed by lambda function ${var.function_name}"
+  description        = "Role assumed by ${var.function_name} lambda"
   assume_role_policy = data.aws_iam_policy_document.assume-role-policy.json
+  tags               = local.tags
+
+  lifecycle {
+    ignore_changes = [
+      # Don't replace role if description is changed.
+      description,
+    ]
+  }
 }
 
 resource "aws_iam_role_policy_attachment" "default" {

--- a/main.tf
+++ b/main.tf
@@ -1,18 +1,21 @@
 resource "aws_cloudwatch_log_group" "default" {
-  name = "/aws/lambda/${var.function_name}"
+  name              = "/aws/lambda/${var.function_name}"
+  retention_in_days = var.retention
+  tags              = local.tags
 }
 
 locals {
   lambda_zip = "lambda/splunk-cloudwatch-logs-processor.zip"
+  tags       = merge({ Name = var.function_name }, var.tags)
 }
 
 resource "aws_lambda_function" "default" {
-  description = "Stream events from AWS CloudWatch to Splunk event collector"
-
-  # The function_name, runtime, memory_size, and timeout use variables
-  # to facilitate testing of both new runtimes and new function versions.
-  # End users will ordinarily use the default values.
+  description   = "Stream events from AWS CloudWatch to Splunk event collector"
   function_name = var.function_name
+
+  # The runtime, memory_size, and timeout are defined as examples to
+  # facilitate testing and deployment new function versions and upgrades
+  # to runtime versions. End users will ordinarily use the default values.
 
   runtime          = var.runtime
   memory_size      = var.memory_size
@@ -22,7 +25,7 @@ resource "aws_lambda_function" "default" {
   role             = aws_iam_role.default.arn
   filename         = local.lambda_zip
   source_code_hash = filebase64sha256(local.lambda_zip)
-  tags             = var.tags
+  tags             = local.tags
 
   environment {
     variables = {

--- a/variables.tf
+++ b/variables.tf
@@ -1,11 +1,11 @@
 ##### Variables for aws_lambda_function resource.
 
-# The function_name, runtime, memory_size, and timeout use variables
-# to facilitate testing of both new runtimes and new function versions.
-# End users will ordinarily use the default values.
+# The runtime, memory_size, and timeout are defined as examples to
+# facilitate testing and deployment new function versions and upgrades
+# to runtime versions. End users will ordinarily use the default values.
 
 variable "function_name" {
-  description = "Name of the lambda function and role to be deployed"
+  description = "Name of lambda function to be deployed"
   default     = "cloudwatch-to-splunk"
 }
 
@@ -14,13 +14,14 @@ variable "memory_size" {
   default     = 512
 }
 
-variable "runtime" {
-  description = "Lambda function's runtime environment"
+variable "retention" {
+  description = "Log retention period in days"
+  type        = number
+  default     = 30
 }
 
-variable "timeout" {
-  description = "Time limit in seconds for lambda function"
-  default     = 10
+variable "runtime" {
+  description = "Lambda function's runtime environment"
 }
 
 variable "splunk_cache_ttl" {
@@ -36,7 +37,12 @@ variable "ssm_prefix" {
 }
 
 variable "tags" {
-  description = "A mapping of tags to be supplied to resources where supported"
+  description = "Map of tags to be supplied to resources where supported"
   type        = map(string)
   default     = {}
+}
+
+variable "timeout" {
+  description = "Time limit in seconds for lambda function"
+  default     = 10
 }


### PR DESCRIPTION
To be consistent with other defaults, the default retention for logs produced by this lambda function is set to 30 days.